### PR TITLE
SNIP-9: Adding a new Cairo-2 compatible version for OutsideExecution …

### DIFF
--- a/SNIPS/snip-9.md
+++ b/SNIPS/snip-9.md
@@ -1,7 +1,7 @@
 ---
 snip: 9
 title: Outside execution
-authors: Argent Labs <argent.xyz>, AVNU <avnu.fi>
+authors: Argent Labs <argent.xyz>, AVNU <avnu.fi>, Braavos <braavos.app>
 discussions-to: https://community.starknet.io/t/snip-outside-execution/101058
 status: Draft
 type: Standards Track
@@ -44,19 +44,91 @@ struct OutsideExecution {
 - **execute_{before,after}**: timestamp range in which the execution is allowed.
 - **calls**: the usual calls to be executed by the account.
 
-### 2. Sign it using ERC-712 typed data hashing
+### 2. Sign it using SNIP-12 typed data hashing
 
-Reference implementation: [https://github.com/argentlabs/argent-contracts-starknet/blob/main/tests/lib/outsideExecution.ts](https://github.com/argentlabs/argent-contracts-starknet/blob/main/tests/lib/outsideExecution.ts)
+#### 2.1. Version 1
 
-See this SNIP for more info on offchain signatures on Starknet: [https://community.starknet.io/t/snip-off-chain-signatures-a-la-eip712/98029](https://community.starknet.io/t/snip-off-chain-signatures-a-la-eip712/98029)
+With [domain_separator](https://github.com/starknet-io/SNIPs/blob/main/SNIPS/snip-12.md#domain-separator) parameters:
+- `name` is set to  `Account.execute_from_outside`
+- `version` is set to  `1`
+
+and `OutsideExecution` type defined as:
+```rust
+  OutsideExecution: [
+    { name: "caller", type: "felt" },
+    { name: "nonce", type: "felt" },
+    { name: "execute_after", type: "felt" },
+    { name: "execute_before", type: "felt" },
+    { name: "calls_len", type: "felt" },
+    { name: "calls", type: "OutsideCall*" },
+  ],
+  OutsideCall: [
+    { name: "to", type: "felt" },
+    { name: "selector", type: "felt" },
+    { name: "calldata_len", type: "felt" },
+    { name: "calldata", type: "felt*" },
+  ]
+```
+
+The type hash of `OutsideExecution` is then:
+**`H('OutsideExecution(caller:felt,nonce:felt,execute_after:felt,execute_before:felt,calls_len:felt,calls:OutsideCall*)OutsideCall(to:felt,selector:felt,calldata_len:felt,calldata:felt*)')`**
+
+which results in `0x11ff76fe3f640fa6f3d60bbd94a3b9d47141a2c96f87fdcfbeb2af1d03f7050`
+
+And the type hash of `OutsideCall` is:
+**`H('OutsideCall(to:felt,selector:felt,calldata_len:felt,calldata:felt*)')`**
+
+which results in `0xf00de1fccbb286f9a020ba8821ee936b1deea42a5c485c11ccdc82c8bebb3a`
+
+Refer to this implementation: [https://github.com/argentlabs/argent-contracts-starknet/blob/main/tests/lib/outsideExecution.ts](https://github.com/argentlabs/argent-contracts-starknet/blob/main/tests/lib/outsideExecution.ts)
+
+#### 2.2. Version 2
+
+In [domain_seperator](https://github.com/starknet-io/SNIPs/blob/main/SNIPS/snip-12.md#domain-separator):
+- `version` is set to `2`
+
+In `OutsideExecution` type definition:
+
+- **caller**: changed to type `ContractAddress`
+- **execute_{before,after}**: changed to type `u128`
+- **calls_len**: **removed** from hash
+- **calls**: changed to Corelib's type `Call*`
+
+So the version `2` type definition to sign is:
+```rust
+  OutsideExecution: [
+    { name: "Caller", type: "ContractAddress" },
+    { name: "Nonce", type: "felt" },
+    { name: "Execute After", type: "u128" },
+    { name: "Execute Before", type: "u128" },
+    { name: "Calls", type: "Call*" },
+  ],
+  Call: [
+    { name: "To", type: "ContractAddress" },
+    { name: "Selector", type: "selector" },
+    { name: "Calldata", type: "felt*" },
+  ]
+```
+The type hash of `OutsideExecution` is then:
+
+**`H('"OutsideExecution"("Caller":"ContractAddress","Nonce":"felt","Execute After":"u128","Execute Before":"u128","Calls":"Call*")"Call"("To":"ContractAddress","Selector":"selector","Calldata":"felt*")')`**
+
+which results in `0x312b56c05a7965066ddbda31c016d8d05afc305071c0ca3cdc2192c3c2f1f0f`
+
+And the type hash of `Call` is:
+**`H('"Call"("To":"ContractAddress","Selector":"selector","Calldata":"felt*")')`**
+
+which results in `0x3635c7f2a7ba93844c0d064e18e487f35ab90f7c39d00f186a781fc3f0c2ca9`
+
+See [SNIP 12](https://github.com/starknet-io/SNIPs/blob/main/SNIPS/snip-12.md) for more info on offchain signatures on Starknet
 
 ### 3. Pass the structure and signature to the account
 
 Check if the account supports this SNIP:
 
 ```rust
-let account = IErc165Dispatcher { contract_address: acount_address };
-let is_supported = account.supports_interface(ERC165_OUTSIDE_EXECUTION_INTERFACE_ID); // see below for actual value
+let account = ISRC5Dispatcher { contract_address: acount_address };
+let is_supported = account.supports_interface(SRC5_OUTSIDE_EXECUTION_INTERFACE_ID); // see below for actual value
 ```
 
 Call the `execute_from_outside` method on the account:
@@ -70,16 +142,28 @@ let results = account.execute_from_outside(outside_execution, signature);
 
 ### For account builders
 
-To accept such outside transactions, the account contract must implement the following interface:
+#### Version 1
+
+This version implements [SNIP-12 revision 0](https://github.com/starknet-io/SNIPs/blob/main/SNIPS/snip-12.md#specification). To accept such outside transactions with [domain_separator](https://github.com/starknet-io/SNIPs/blob/main/SNIPS/snip-12.md#domain-separator) parameter `version` set to  `1`, the account contract must implement the following interface:
 
 ```rust
 /// Interface ID: 0x68cfd18b92d1907b8ba3cc324900277f5a3622099431ea85dd8089255e4181
+#[derive(Copy, Drop, Serde)]
+struct OutsideExecution {
+    caller: ContractAddress,
+    nonce: felt252,
+    execute_after: u64,
+    execute_before: u64,
+    calls: Span<Call>
+}
+
 #[starknet::interface]
 trait IOutsideExecution<TContractState> {
-    /// This method allows anyone to submit a transaction on behalf of the account as long as they have the relevant signatures. This method allows reentrancy. A call to `__execute__` or `execute_from_outside` can trigger another nested transaction to `execute_from_outside`.
+    /// This method allows anyone to submit a transaction on behalf of the account as long as they have the relevant signatures.
+    /// This method allows reentrancy. A call to `__execute__` or `execute_from_outside` can trigger another nested transaction to `execute_from_outside` thus the implementation MUST verify that the provided `signature` matches the hash of `outside_execution` and that `nonce` was not already used.
     /// # Arguments
     /// * `outside_execution ` - The parameters of the transaction to execute.
-    /// * `signature ` - A valid signature on the ERC-712 message encoding of `outside_execution`.
+    /// * `signature ` - A valid signature on the SNIP-12 message encoding of `outside_execution`.
     fn execute_from_outside(
         ref self: TContractState,
         outside_execution: OutsideExecution,
@@ -93,6 +177,48 @@ trait IOutsideExecution<TContractState> {
     ) -> bool;
 }
 ```
+
+#### Version 2
+
+This version implements [SNIP-12 revision 1](https://github.com/starknet-io/SNIPs/blob/main/SNIPS/snip-12.md#specification). To accept such outside transactions with [domain_separator](https://github.com/starknet-io/SNIPs/blob/main/SNIPS/snip-12.md#domain-separator) parameter `version` set to  `2`, the account contract must implement the following interface:
+
+```rust
+/// Interface ID: 0x1d1144bb2138366ff28d8e9ab57456b1d332ac42196230c3a602003c89872
+#[derive(Copy, Drop, Serde)]
+struct OutsideExecution {
+    caller: ContractAddress,
+    nonce: felt252,
+    // note that the type here is u64 and not u128 as defined in the type hash definition
+    // u64 matches the type of block_timestamp in Corelib's BlockInfo struct
+    execute_after: u64,
+    execute_before: u64,
+    calls: Span<Call>
+}
+
+#[starknet::interface]
+trait IOutsideExecution_V2<TContractState> {
+    /// This method allows anyone to submit a transaction on behalf of the account as long as they have the relevant signatures.
+    /// This method allows reentrancy. A call to `__execute__` or `execute_from_outside` can trigger another nested transaction to `execute_from_outside` thus the implementation MUST verify that the provided `signature` matches the hash of `outside_execution` and that `nonce` was not already used.
+    /// The implementation should expect version to be set to 2 in the domain separator.
+    /// # Arguments
+    /// * `outside_execution ` - The parameters of the transaction to execute.
+    /// * `signature ` - A valid signature on the SNIP-12 message encoding of `outside_execution`.
+    fn execute_from_outside_v2(
+        ref self: TContractState,
+        outside_execution: OutsideExecution,
+        signature: Span<felt252>,
+    ) -> Array<Span<felt252>>;
+
+    /// Get the status of a given nonce, true if the nonce is available to use
+    fn is_valid_outside_execution_nonce(
+        self: @TContractState,
+        nonce: felt252
+    ) -> bool;
+}
+```
+
+**NOTE**: The interface id for version 2 is computed with a Cairo v2.5.0 compatible `Call` struct where `calldata` is a `Span<felt252>`
+
 
 Indicative implementation outline:
 


### PR DESCRIPTION
…type hashing (#76)

* Adding a new version for OutsideExecution type hashing

Details added to section 2.1 & 2.2

Adding call type hash info

Editing

Editing

* Adding a unique interface for the v2 outside execution interface

* Updating type object based on suggestions and adding JSON escaping based on snip-12 rev1

* Added comment concerning snip-12 revision for each version

* Added OutsideExecution struct definition in the account builder section

* fix(SNIP-9): Use Span<> instead of Array<> for signature and Call.calldata and  align inteface id + clarify comment about re-entrance